### PR TITLE
Accelerate SDXL VAE using NATTEN local neighbourhood attention

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -67,5 +67,12 @@
       "module": "scripts.in_between_test",
       "justMyCode": false,
     },
+    {
+      "name": "Python: VAE roundtrip",
+      "type": "python",
+      "request": "launch",
+      "module": "scripts.vae_roundtrip",
+      "justMyCode": false,
+    },
   ]
 }

--- a/scripts/vae_roundtrip.py
+++ b/scripts/vae_roundtrip.py
@@ -8,6 +8,7 @@ from diffusers.models.vae import DecoderOutput, DiagonalGaussianDistribution
 from PIL import Image
 import numpy as np
 from src.attn.natten_attn_processor import NattenAttnProcessor
+from src.attn.qkv_fusion import fuse_vae_qkv
 
 device = torch.device('cuda')
 
@@ -26,8 +27,10 @@ vae: AutoencoderKL = AutoencoderKL.from_pretrained(
   use_safetensors=True,
   **vae_kwargs,
 )
-vae.set_attn_processor(NattenAttnProcessor())
-# vae.enable_slicing()
+fuse_vae_qkv(vae)
+# you'll need a dev build of NATTEN to use kernel sizes as large as 17. otherwise you'll have to go down to 13.
+vae.set_attn_processor(NattenAttnProcessor(kernel_size=17))
+# vae.enable_slicing() # you probably don't need this any more
 vae.eval().to(device)
 
 def load_img(path) -> FloatTensor:

--- a/scripts/vae_roundtrip.py
+++ b/scripts/vae_roundtrip.py
@@ -1,0 +1,57 @@
+from typing import Dict, Any
+import torch
+from torch import inference_mode, FloatTensor
+from torchvision.utils import save_image
+from diffusers import AutoencoderKL
+from diffusers.models.autoencoder_kl import DecoderOutput, AutoencoderKLOutput
+from diffusers.models.vae import DecoderOutput, DiagonalGaussianDistribution
+from PIL import Image
+import numpy as np
+
+device = torch.device('cuda')
+
+use_ollin_vae = True
+vae_kwargs: Dict[str, Any] = {
+  'torch_dtype': torch.float16,
+} if use_ollin_vae else {
+  'variant': 'fp16',
+  'subfolder': 'vae',
+  # decoder gets NaN result in float16.
+  'torch_dtype': torch.bfloat16 if torch.cuda.is_available() and torch.cuda.is_bf16_supported() else torch.float32,
+}
+
+vae: AutoencoderKL = AutoencoderKL.from_pretrained(
+  'madebyollin/sdxl-vae-fp16-fix' if use_ollin_vae else 'stabilityai/stable-diffusion-xl-base-0.9',
+  use_safetensors=True,
+  **vae_kwargs,
+)
+# vae.set_attn_processor(SlicedAttnProcessor())
+# vae.enable_slicing()
+vae.eval().to(device)
+
+def load_img(path) -> FloatTensor:
+  image: Image.Image = Image.open(path).convert("RGB")
+  w, h = image.size
+  print(f"loaded input image of size ({w}, {h}) from {path}")
+  img_arr: np.ndarray = np.array(image)
+  del image
+  img_tensor: FloatTensor = torch.from_numpy(img_arr).to(dtype=torch.float32)
+  del img_arr
+  # TODO: would contiguous() make it faster to convolve over this?
+  img_tensor: FloatTensor = img_tensor.permute(2, 0, 1).unsqueeze(0)
+  img_tensor: FloatTensor = img_tensor / 127.5 - 1.0
+  return img_tensor
+img: FloatTensor = load_img('in.jpg')
+
+generator = torch.Generator(device='cpu')
+generator.manual_seed(42)
+
+with inference_mode():
+  encoded: AutoencoderKLOutput = vae.encode(img.to(device, vae.dtype))
+  dist: DiagonalGaussianDistribution = encoded.latent_dist
+  latents: FloatTensor = dist.sample(generator=generator)
+  decoder_out: DecoderOutput = vae.decode(latents)
+
+sample: FloatTensor = decoder_out.sample.div(2).add_(.5).clamp_(0,1)
+
+save_image(sample, 'out.png')

--- a/scripts/vae_roundtrip.py
+++ b/scripts/vae_roundtrip.py
@@ -7,6 +7,7 @@ from diffusers.models.autoencoder_kl import DecoderOutput, AutoencoderKLOutput
 from diffusers.models.vae import DecoderOutput, DiagonalGaussianDistribution
 from PIL import Image
 import numpy as np
+from src.attn.natten_attn_processor import NattenAttnProcessor
 
 device = torch.device('cuda')
 
@@ -25,7 +26,7 @@ vae: AutoencoderKL = AutoencoderKL.from_pretrained(
   use_safetensors=True,
   **vae_kwargs,
 )
-# vae.set_attn_processor(SlicedAttnProcessor())
+vae.set_attn_processor(NattenAttnProcessor())
 # vae.enable_slicing()
 vae.eval().to(device)
 

--- a/src/attn/natten_attn_processor.py
+++ b/src/attn/natten_attn_processor.py
@@ -1,0 +1,88 @@
+import torch.nn.functional as F
+from diffusers.models.attention import Attention
+
+class NattenAttnProcessor:
+    r"""
+    Processor for implementing local neighbourhood attention via NATTEN
+    Based on:
+    https://github.com/huggingface/diffusers/blob/3105c710ba16fa2cf54d8deb158099a4146da511/src/diffusers/models/attention_processor.py
+    Once complete: this will make query tokens attend only to key tokens within a certain distance (local neighbourhood).
+    """
+
+    def __init__(self):
+        # TODO: check for NATTEN
+        pass
+
+    def __call__(
+        self,
+        attn: Attention,
+        hidden_states,
+        encoder_hidden_states=None,
+        attention_mask=None,
+        temb=None,
+    ):
+        residual = hidden_states
+
+        if attn.spatial_norm is not None:
+            hidden_states = attn.spatial_norm(hidden_states, temb)
+
+        input_ndim = hidden_states.ndim
+
+        if input_ndim == 4:
+            batch_size, channel, height, width = hidden_states.shape
+            hidden_states = hidden_states.view(batch_size, channel, height * width).transpose(1, 2)
+
+        batch_size, sequence_length, _ = (
+            hidden_states.shape if encoder_hidden_states is None else encoder_hidden_states.shape
+        )
+        inner_dim = hidden_states.shape[-1]
+
+        if attention_mask is not None:
+            attention_mask = attn.prepare_attention_mask(attention_mask, sequence_length, batch_size)
+            # scaled_dot_product_attention expects attention_mask shape to be
+            # (batch, heads, source_length, target_length)
+            attention_mask = attention_mask.view(batch_size, attn.heads, -1, attention_mask.shape[-1])
+
+        if attn.group_norm is not None:
+            hidden_states = attn.group_norm(hidden_states.transpose(1, 2)).transpose(1, 2)
+
+        query = attn.to_q(hidden_states)
+
+        if encoder_hidden_states is None:
+            encoder_hidden_states = hidden_states
+        elif attn.norm_cross:
+            encoder_hidden_states = attn.norm_encoder_hidden_states(encoder_hidden_states)
+
+        key = attn.to_k(encoder_hidden_states)
+        value = attn.to_v(encoder_hidden_states)
+
+        head_dim = inner_dim // attn.heads
+
+        query = query.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        key = key.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+        value = value.view(batch_size, -1, attn.heads, head_dim).transpose(1, 2)
+
+        # the output of sdp = (batch, num_heads, seq_len, head_dim)
+        # TODO: add support for attn.scale when we move to Torch 2.1
+        hidden_states = F.scaled_dot_product_attention(
+            query, key, value, attn_mask=attention_mask, dropout_p=0.0, is_causal=False
+        )
+
+        hidden_states = hidden_states.transpose(1, 2).reshape(batch_size, -1, attn.heads * head_dim)
+        hidden_states = hidden_states.to(query.dtype)
+
+        # linear proj
+        hidden_states = attn.to_out[0](hidden_states)
+        # dropout
+        hidden_states = attn.to_out[1](hidden_states)
+
+        if input_ndim == 4:
+            hidden_states = hidden_states.transpose(-1, -2).reshape(batch_size, channel, height, width)
+
+        if attn.residual_connection:
+            hidden_states = hidden_states + residual
+
+        hidden_states = hidden_states / attn.rescale_output_factor
+
+        return hidden_states

--- a/src/attn/null_attn_processor.py
+++ b/src/attn/null_attn_processor.py
@@ -1,0 +1,49 @@
+from diffusers.models.attention import Attention
+from torch import FloatTensor, BoolTensor
+from typing import Optional
+from einops import rearrange
+
+class NullAttnProcessor:
+    r"""
+    Processor for skipping SDP attn, for cases where we suspect it's learned to drop out the token-mixing capability
+    Based on:
+    https://github.com/huggingface/diffusers/blob/3105c710ba16fa2cf54d8deb158099a4146da511/src/diffusers/models/attention_processor.py
+    """
+
+    def __call__(
+        self,
+        attn: Attention,
+        hidden_states: FloatTensor,
+        encoder_hidden_states: Optional[FloatTensor] = None,
+        attention_mask: Optional[BoolTensor] = None,
+        temb: Optional[FloatTensor] = None,
+    ):
+        residual = hidden_states
+
+        if attn.spatial_norm is not None:
+            hidden_states = attn.spatial_norm(hidden_states, temb)
+
+        if attention_mask is not None:
+            raise ValueError("attn key masking not implemented, because this experiment altogether disables mixing of values based on qk-similarity")
+        if encoder_hidden_states is not None:
+            raise ValueError("cross-attn not implemented, because this experiment altogether disables mixing of values based on qk-similarity")
+
+        if attn.group_norm is not None:
+            hidden_states = attn.group_norm(hidden_states)
+            hidden_states = rearrange(hidden_states, '... c h w -> ... h w c')
+        
+        v = attn.to_v(hidden_states)
+        v = rearrange(v, "n h w (nh e) -> n nh h w e", e=attn.to_v.out_features)
+        hidden_states = rearrange(v, "n nh h w e -> n h w (nh e)")
+        del v
+
+        linear_proj, dropout = attn.to_out
+        hidden_states = linear_proj(hidden_states)
+        hidden_states = dropout(hidden_states)
+
+        hidden_states = rearrange(hidden_states, '... h w c -> ... c h w')
+
+        if attn.residual_connection:
+            hidden_states = hidden_states + residual
+
+        return hidden_states

--- a/src/attn/qkv_fusion.py
+++ b/src/attn/qkv_fusion.py
@@ -1,0 +1,18 @@
+from diffusers import AutoencoderKL
+from diffusers.models.attention import Attention
+import torch
+from torch.nn import Linear
+
+def fuse_qkv(attn: Attention) -> None:
+    has_bias = attn.to_q.bias is not None
+    # throughout, we assume MHA (as opposed to GQA)
+    qkv = Linear(in_features=attn.to_q.in_features, out_features=attn.to_q.out_features*3, bias=has_bias, dtype=attn.to_q.weight.dtype, device=attn.to_q.weight.device)
+    qkv.weight.data.copy_(torch.cat([attn.to_q.weight.data * attn.scale, attn.to_k.weight.data, attn.to_v.weight.data]))
+    if has_bias:
+        qkv.bias.data.copy_(torch.cat([attn.to_q.bias.data * attn.scale, attn.to_k.bias.data, attn.to_v.bias.data]))
+    setattr(attn, 'qkv', qkv)
+    del attn.to_q, attn.to_k, attn.to_v
+
+def fuse_vae_qkv(vae: AutoencoderKL) -> None:
+    for attn in [*vae.encoder.mid_block.attentions, *vae.decoder.mid_block.attentions]:
+        fuse_qkv(attn)


### PR DESCRIPTION
Accelerate SDXL VAE using NATTEN local neighbourhood attention

Thanks @crowsonkb for the idea!

Install natten from source like so:

```bash
git clone https://github.com/SHI-Labs/NATTEN.git
cd NATTEN
pip install cmake==3.20.3
CUDACXX=/usr/local/cuda/bin/nvcc make CUDA_ARCH="8.9" WORKERS=2
```

or get latest stable from pip:

```bash
pip install natten -f https://shi-labs.com/natten/wheels/cu121/torch2.1.0/index.html
```

Input image:  
![in](https://github.com/Birch-san/sdxl-play/assets/6141784/ce607596-1c49-4eed-ba48-7096792a3a8d)

Output image after VAE round-trip (global self-attention):  
![out expected](https://github.com/Birch-san/sdxl-play/assets/6141784/78327c7c-5d8f-4277-b53a-5791eaae0dad)

Output image after VAE round-trip (local neighbourhood attention, kernel size 17):  
![out outproj17fused](https://github.com/Birch-san/sdxl-play/assets/6141784/e38382ed-14b3-4d97-965f-ba4d67a7139c)  
This looks identical to global self-attention, whilst requiring far less memory and compute.

Output image after VAE round-trip (local neighbourhood attention, kernel size 3):  
![out natten3](https://github.com/Birch-san/sdxl-play/assets/6141784/4e780ed7-485e-49ce-af60-ec7e775b9fef)  
This looks _nearly_ identical to global self-attention, requiring _even less_ memory and compute.

## Null attention

It looks like there's not actually much similarity-based mixing of information between tokens. so what happens if we just drop scaled dot product attention altogether?

so instead of:  
`softmax(Q•K.mT*scale)•V•O`

we just do:  
`V•O`

Output image after VAE round-trip (null attention):  
![out null](https://github.com/Birch-san/sdxl-play/assets/6141784/f19a399c-4446-4f58-9cd3-942491cfbd16)

It's not _identical_ to global self-attention, but it's pretty close. and _far_ cheaper & more scalable than global self-attention (in compute and in memory).